### PR TITLE
CMakeLists.txt: Adds config support for error strings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ cmake_dependent_option(FT_REQUIRE_BROTLI
   "Require support of compressed WOFF2 fonts." OFF
   "NOT FT_DISABLE_BROTLI" OFF)
 
+option(FT_ENABLE_ERROR_STRINGS
+  "Enable suport for meaningful error descriptions" OFF)
 
 # Disallow in-source builds
 if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
@@ -351,6 +353,11 @@ endif ()
 if (BROTLIDEC_FOUND)
   string(REGEX REPLACE
     "/\\* +(#define +FT_CONFIG_OPTION_USE_BROTLI) +\\*/" "\\1"
+    FTOPTION_H "${FTOPTION_H}")
+endif ()
+if (FT_ENABLE_ERROR_STRINGS)
+  string(REGEX REPLACE
+    "/\\* +(#define +FT_CONFIG_OPTION_ERROR_STRINGS) +\\*/" "\\1"
     FTOPTION_H "${FTOPTION_H}")
 endif ()
 


### PR DESCRIPTION
Add CMake option FT_ENABLE_ERROR_STRINGS to uncomment
FT_CONFIG_OPTION_ERROR_STRINGS. This make FT_Error_String
return meaningful error strings.
This option is off by default.