### PR TITLE
Fix cmake 4 error by specifying the policy version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@
 #   support).
 
 # CMake 3.12 provides for IMPORTED targets for common libraries like zlib, libpng and bzip2
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.31.0)
 
 include(CheckIncludeFile)
 include(CMakeDependentOption)


### PR DESCRIPTION
Adding a policy version since its mandatory with cmake 4 https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html